### PR TITLE
fix types in tests + fix seeds in withdraw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 target
 **/*.rs.bk
 node_modules
+
+.idea

--- a/programs/governance-registry/src/context.rs
+++ b/programs/governance-registry/src/context.rs
@@ -191,7 +191,7 @@ pub struct Withdraw<'info> {
     pub voting_token: Account<'info, TokenAccount>,
     #[account(
         mut,
-        seeds = [registrar.load()?.realm.as_ref(), voting_token.mint.as_ref()],
+        seeds = [registrar.key().as_ref(), withdraw_mint.key().as_ref()],
         bump,
     )]
     pub voting_mint: Account<'info, Mint>,

--- a/tests/governance-registry.ts
+++ b/tests/governance-registry.ts
@@ -272,7 +272,6 @@ describe("voting-rights", () => {
     assert.ok(vtAccount.amount.toNumber() === 10);
   });
 
-  /*
   it("Withdraws cliff locked A tokens", async () => {
     const depositId = 0;
     const amount = new BN(10);
@@ -283,7 +282,7 @@ describe("voting-rights", () => {
         exchangeVault: exchangeVaultA,
         withdrawMint: mintA,
         votingToken,
-        votingMint,
+        votingMint: votingMintA,
         destination: godA,
         authority: program.provider.wallet.publicKey,
         tokenProgram,
@@ -293,13 +292,12 @@ describe("voting-rights", () => {
     const voterAccount = await program.account.voter.fetch(voter);
     const deposit = voterAccount.deposits[0];
     assert.ok(deposit.isUsed);
-    assert.ok(deposit.amount.toNumber() === 0);
+    assert.ok(deposit.amountDeposited.toNumber() === 0);
     assert.ok(deposit.rateIdx === 0);
 
-    const vtAccount = await votingTokenClient.getAccountInfo(votingToken);
+    const vtAccount = await votingTokenClientA.getAccountInfo(votingToken);
     assert.ok(vtAccount.amount.toNumber() === 0);
   });
-  */
 
   it("Deposits daily locked A tokens", async () => {
     const amount = new BN(10);
@@ -325,7 +323,7 @@ describe("voting-rights", () => {
     });
 
     const voterAccount = await program.account.voter.fetch(voter);
-    const deposit = voterAccount.deposits[0];
+    const deposit = voterAccount.deposits[1];
     assert.ok(deposit.isUsed);
     assert.ok(deposit.amountDeposited.toNumber() === 10);
     assert.ok(deposit.rateIdx === 0);


### PR DESCRIPTION
Withdraw test still as expected fails with InsufficientVestedTokens. We need to figure out a solution for time travelling.
Signed-off-by: microwavedcola1 <microwavedcola@gmail.com>